### PR TITLE
Revision bounding polynomials CAMCoS

### DIFF
--- a/EEs/Iterative_method_comparison/pstar_quad_TR.f90
+++ b/EEs/Iterative_method_comparison/pstar_quad_TR.f90
@@ -117,7 +117,8 @@ double precision function pStarNonVacuum(gamma,pL,uL,rhoL,pR,uR,rhoR,aL,aR,tol,i
         ! Before starting we improve the estimate from below via one 'classic' Newton iteration
         ! For this iteration we start with p2 which is the best estimate we have so far
         ! NOTE: due to the concavity of phi, the classic Newton iteration always estimates from below
-        p1 = max(p1,p2-phi(gamma,p2,pL,uL,rhoL,pR,uR,rhoR,aL,aR,CL,CR,BL,BR)/phip(gamma,p2,pL,uL,rhoL,pR,uR,rhoR,aL,aR,CL,CR,BL,BR))     
+        phiR = phi(gamma,p2,pL,uL,rhoL,pR,uR,rhoR,aL,aR,CL,CR,BL,BR)
+        p1 = max(p1,p2-phiR/phip(gamma,p2,pL,uL,rhoL,pR,uR,rhoR,aL,aR,CL,CR,BL,BR))     
         !Start iterative process 
         iterations_single_RP=0 !to know where to stop if diverges
         do while(.true.)
@@ -127,11 +128,10 @@ double precision function pStarNonVacuum(gamma,pL,uL,rhoL,pR,uR,rhoR,aL,aR,tol,i
             end if
 
             !Save old estimates of pstar 
-            p1_old = p1
+            !p1_old = p1
             p2_old = p2
             !Compute new estimates of pstar
-            p1 = p1FromQuadPhiFromAbove(gamma,p1,p2,pL,uL,rhoL,pR,uR,rhoR,aL,aR,CL,CR,BL,BR)
-            p2 = p2FromQuadPhiFromBelow(gamma,p1,p2,pL,uL,rhoL,pR,uR,rhoR,aL,aR,CL,CR,BL,BR)
+            p2 = p2FromQuadPhiFromBelow(gamma,p1,p2,pL,uL,rhoL,pR,uR,rhoR,aL,aR,CL,CR,BL,BR,phiR)
             iterations=iterations+1
             iterations_single_RP=iterations_single_RP+1
             !Evaluate depth function from the right 
@@ -280,7 +280,7 @@ double precision function p1FromQuadPhiFromAbove(gamma,p1,p2,pL,uL,rhoL,pR,uR,rh
                            (phip(gamma,p1,pL,uL,rhoL,pR,uR,rhoR,aL,aR,CL,CR,BL,BR)+dsqrt(Delta))
 END function p1FromQuadPhiFromAbove
 
-double precision function p2FromQuadPhiFromBelow(gamma,p1,p2,pL,uL,rhoL,pR,uR,rhoR,aL,aR,CL,CR,BL,BR)
+double precision function p2FromQuadPhiFromBelow(gamma,p1,p2,pL,uL,rhoL,pR,uR,rhoR,aL,aR,CL,CR,BL,BR,phiR)
   ! We start considering two estimates of pStar. One from the left(p1) and one from the right(p2). 
   ! We use these estimates to construct (a priori) a quadratic approximation of phi from below. 
   ! This quad approximation is monotonically increasing and concave down (just as phi). 
@@ -288,9 +288,10 @@ double precision function p2FromQuadPhiFromBelow(gamma,p1,p2,pL,uL,rhoL,pR,uR,rh
   implicit none
   double precision :: gamma,p1,p2,pL,uL,rhoL,pR,uR,rhoR,aL,aR,CL,CR,BL,BR
   double precision :: Delta, phip, phi , phidd122
+  double precision :: phiR
   
   Delta = phip(gamma,p2,pL,uL,rhoL,pR,uR,rhoR,aL,aR,CL,CR,BL,BR)**2.d0 - &
-          4.d0*phi(gamma,p2,pL,uL,rhoL,pR,uR,rhoR,aL,aR,CL,CR,BL,BR)*phidd122(gamma,p1,p2,pL,uL,rhoL,pR,uR,rhoR,aL,aR,CL,CR,BL,BR)
+          4.d0*phiR*phidd122(gamma,p1,p2,pL,uL,rhoL,pR,uR,rhoR,aL,aR,CL,CR,BL,BR)
   if (Delta<0) then 
      print *, 'Delta < 0 when computing the root of the quad approx of phi from above'
      print *, "pL: ", pL, " pR: ", pR
@@ -298,7 +299,7 @@ double precision function p2FromQuadPhiFromBelow(gamma,p1,p2,pL,uL,rhoL,pR,uR,rh
      print *, 'Delta: ', Delta
      call abort
   END if
-  p2FromQuadPhiFromBelow = p2 - 2.d0*phi(gamma,p2,pL,uL,rhoL,pR,uR,rhoR,aL,aR,CL,CR,BL,BR)/  &
+  p2FromQuadPhiFromBelow = p2 - 2.d0*phiR/  &
                            (phip(gamma,p2,pL,uL,rhoL,pR,uR,rhoR,aL,aR,CL,CR,BL,BR)+dsqrt(Delta))
 
 END function p2FromQuadPhiFromBelow

--- a/EEs/Iterative_method_comparison/test_time.py
+++ b/EEs/Iterative_method_comparison/test_time.py
@@ -1,7 +1,7 @@
 ####################
 #IMPORTING MODULES
 ####################
-
+print("Importing modules...")
 import numpy as np
 import random
 
@@ -15,6 +15,9 @@ import modules.gottlieb as gottlieb
 import modules.van_leer_TS as van_leer_TS
 import modules.mod_newton_TS as mod_newton_TS
 import modules.quad_TR as quad_TR
+import modules.quad_below_TR as quad_below_TR
+import modules.linear_TR as linear_TR
+print("Modules imported")
 random.seed(1)
 
 #as in the repo
@@ -26,12 +29,13 @@ lenmatrix=lenmatrix_strong+lenmatrix_weak
 ####################
 #INITIALIZING MATRIX
 ####################
-
+print("Generating dataset of Riemann problems...")
 #Harder problems
 matrix=[[10**random.uniform(-2,2),10**random.uniform(-1,1),random.uniform(0.01,0.9),10**random.uniform(-2,2),-10**random.uniform(-1,1),random.uniform(0.01,0.9)] for i in range(lenmatrix_strong)]
 
 #Adding easier problems
 matrix=matrix+[[random.uniform(0.1,1),0.0,random.uniform(0.01,0.9),random.uniform(0.1,1),0.0,random.uniform(0.01,0.9)] for i in range(lenmatrix_weak)]
+print("Dataset generated")
 
 i=0
 while False:
@@ -48,23 +52,25 @@ while False:
 		break
 
 gamma=1.4
+n_runs=7
+
+
+modules=[quad_TR,newton_TS,ostrowski_newton_TS,ostrowski_TS,
+gottlieb,mod_newton_TS,van_leer_TS,quad_below_TR,linear_TR]
+names=["quad_TR","newton_TS","ostrowski_newton_TS","ostrowski_TS",
+"gottlieb","mod_newton_TS","van_leer_TS","quad_below_TR","linear_TR"]
+
 
 tol=1.0E-6
 print("Results tolerance 1.e-6")
-print("Time newton_TS: ",min([newton_TS.pstar(tol=tol,gamma=gamma,conv_criteria=1,rp_data=matrix,n_data=lenmatrix) for i in range(7)]))
-print("Time ostrowski_newton_TS: ",min([ostrowski_newton_TS.pstar(tol=tol,gamma=gamma,conv_criteria=1,rp_data=matrix,n_data=lenmatrix) for i in range(7)]))
-print("Time ostrowski_TS: ",min([ostrowski_TS.pstar(tol=tol,gamma=gamma,conv_criteria=1,rp_data=matrix,n_data=lenmatrix) for i in range(7)]))
-print("Time quad_TR: ",min([quad_TR.pstar(tol=tol,gamma=gamma,conv_criteria=1,rp_data=matrix,n_data=lenmatrix) for i in range(7)]))
-print("Time Gottlieb: ",min([gottlieb.pstar(tol=tol,gamma=gamma,conv_criteria=1,rp_data=matrix,n_data=lenmatrix) for i in range(7)]))
-print("Time Mod Newton TS",min([mod_newton_TS.pstar(tol=tol,gamma=gamma,conv_criteria=1,rp_data=matrix,n_data=lenmatrix) for i in range(7)]))
-print("Time Van Leer TS: ",min([van_leer_TS.pstar(tol=tol,gamma=gamma,conv_criteria=1,rp_data=matrix,n_data=lenmatrix) for i in range(7)]))
+for name,module in zip(names,modules):
+	print("############\nRunning "+name+"...")
+	print("Time "+name+": ",min([module.pstar(tol=tol,gamma=gamma,conv_criteria=1,rp_data=matrix,n_data=lenmatrix) for i in range(n_runs)]))
+	print("############")
 
 tol=1.0E-12
 print("Results tolerance 1.e-12")
-print("Time newton_TS: ",min([newton_TS.pstar(tol=tol,gamma=gamma,conv_criteria=1,rp_data=matrix,n_data=lenmatrix) for i in range(7)]))
-print("Time ostrowski_newton_TS: ",min([ostrowski_newton_TS.pstar(tol=tol,gamma=gamma,conv_criteria=1,rp_data=matrix,n_data=lenmatrix) for i in range(7)]))
-print("Time ostrowski_TS: ",min([ostrowski_TS.pstar(tol=tol,gamma=gamma,conv_criteria=1,rp_data=matrix,n_data=lenmatrix) for i in range(7)]))
-print("Time quad_TR: ",min([quad_TR.pstar(tol=tol,gamma=gamma,conv_criteria=1,rp_data=matrix,n_data=lenmatrix) for i in range(7)]))
-print("Time Gottlieb: ",min([gottlieb.pstar(tol=tol,gamma=gamma,conv_criteria=1,rp_data=matrix,n_data=lenmatrix) for i in range(7)]))
-print("Time Mod Newton TS",min([mod_newton_TS.pstar(tol=tol,gamma=gamma,conv_criteria=1,rp_data=matrix,n_data=lenmatrix) for i in range(7)]))
-print("Time Van Leer TS: ",min([van_leer_TS.pstar(tol=tol,gamma=gamma,conv_criteria=1,rp_data=matrix,n_data=lenmatrix) for i in range(7)]))
+for name,module in zip(names,modules):
+	print("############\nRunning "+name+"...")
+	print("Time "+name+": ",min([module.pstar(tol=tol,gamma=gamma,conv_criteria=1,rp_data=matrix,n_data=lenmatrix) for i in range(n_runs)]))
+	print("############")

--- a/SWEs/Iterative_method_comparison/hstar_quad_below_TR.f90
+++ b/SWEs/Iterative_method_comparison/hstar_quad_below_TR.f90
@@ -1,4 +1,5 @@
-! RS with Quadratic polynomials, 1 Newton step, and TR initial guess
+! RS with a single quadratic polynomial, 1 Newton step, and TR initial guess
+!The quadractic polynomial approximates phi from below between the two bounds
 ! =========================================================
 subroutine hstar(n_data, rp_data,conv_criteria, tol, grav, exec_time)
 ! =========================================================
@@ -97,16 +98,16 @@ double precision function hStarWetStates(g,hL,hR,uL,uR,tol,iterations)
 
     if (iterate==1) then 
         iterations_single_RP=0
-        ! The idea is to construct (a priori) a quadratic approx of phi from above and from below of phi
-        ! and find the root (a priori) of those approximations. 
-        ! Each root will provide new estimates of hStarL and hStarR.
+        ! The idea is to construct (a priori) a quadratic approx of phi  from below 
+        ! and find the root (a priori) of that approximation. 
+        ! The root will provide a new estimates of  hStarR.
         ! We iterate on this process until some tolerance is achieved. 
-        ! Finally, we use the estimate from the right to assure positivity. 
 
         ! Before starting we improve the estimate from below via one 'classic' Newton iteration
         ! For this iteration we start with hStarR which is the best estimate we have so far
         ! NOTE: due to the concavity of phi, the classic Newton iteration always estimates from below
-        hStarL = max(hStarL,hStarR-phi(g,hStarR,hL,hR,uL,uR)/phip(g,hStarR,hL,hR))     
+        phiR = phi(g,hStarR,hL,hR,uL,uR)
+        hStarL = max(hStarL,hStarR-phiR/phip(g,hStarR,hL,hR))     
         iterations=iterations+1
         !Start iterative process 
         do while(.true.)
@@ -115,16 +116,14 @@ double precision function hStarWetStates(g,hL,hR,uL,uR,tol,iterations)
                 exit
             end if
             !Save old estimates of hStar 
-            hStarL_old = hStarL
+            !hStarL_old = hStarL
             hStarR_old = hStarR
             !Compute new estimates of hStar
-            hStarL = hStarLFromQuadPhiFromAbove(g,hStarL_old,hStarR_old,hL,hR,uL,uR)
-            hStarR = hStarRFromQuadPhiFromBelow(g,hStarL_old,hStarR_old,hL,hR,uL,uR)
+            hStarR = hStarRFromQuadPhiFromBelow(g,hStarL,hStarR_old,hL,hR,uL,uR,phiR)
             iterations=iterations+1
             iterations_single_RP=iterations_single_RP+1
             !Evaluate depth function from the right 
             phiR = phi(g,hStarR,hL,hR,uL,uR)
-            !phiL = phi(g,hStarR,hL,hR,uL,uR)
 
             !Check if hStar or phii are NaN. 
             ! This is due to estimates from the left and from the right being the same (hStarL=hStarR)
@@ -227,28 +226,8 @@ double precision function phiDiff(g,hStarL,hStarR,hL,hR,uL,uR)
   end if
 END function phiDiff
 
-double precision function hStarLFromQuadPhiFromAbove(g,hStarL,hStarR,hL,hR,uL,uR)
-  ! We start considering two estimates of hStar. One from the left and one from the right. 
-  ! We use these estimates to construct (a priori) a quadratic approximation of phi from above. 
-  ! This quad approximation is monotonically increasing and concave down (just as phi). 
-  ! We find the root (a priori) of this quadratic approximation to obtain a new estimate of hStar from the left
-  implicit none
-  double precision :: g,hStarL,hStarR,hL,hR,uL,uR
-  double precision :: Delta, phip, phi, phiDDiff1
 
-  Delta = phip(g,hStarL,hL,hR)**2.d0 - 4.d0*phi(g,hStarL,hL,hR,uL,uR)*phiDDiff1(g,hStarL,hStarR,hL,hR,uL,uR)
-  if (Delta<0) then 
-     print *, "hstarL_old: ", hStarL, " hstarR_old: ", hStarR
-     print *, "hL: ", hL, " hR: ", hR
-     print *, "uL: ", uL, " uR: ", uR
-     print *, 'Delta < 0 when computing the root of the quad approx of phi from above'
-     print *, 'Delta: ', Delta
-     call abort
-  END if
-  hStarLFromQuadPhiFromAbove = hStarL - 2.d0*phi(g,hStarL,hL,hR,uL,uR)/(phip(g,hStarL,hL,hR)+sqrt(Delta))
-END function hStarLFromQuadPhiFromAbove
-
-double precision function hStarRFromQuadPhiFromBelow(g,hStarL,hStarR,hL,hR,uL,uR)
+double precision function hStarRFromQuadPhiFromBelow(g,hStarL,hStarR,hL,hR,uL,uR,phiR)
   ! We start considering two estimates of hStar. One from the left and one from the right. 
   ! We use these estimates to construct (a priori) a quadratic approximation of phi from below. 
   ! This quad approximation is monotonically increasing and concave down (just as phi). 
@@ -256,8 +235,10 @@ double precision function hStarRFromQuadPhiFromBelow(g,hStarL,hStarR,hL,hR,uL,uR
   implicit none
   double precision :: g,hStarL,hStarR,hL,hR,uL,uR
   double precision :: Delta, phip, phi, phiDDiff2
+  double precision :: phiR
   
-  Delta = phip(g,hStarR,hL,hR)**2.d0 - 4.d0*phi(g,hStarR,hL,hR,uL,uR)*phiDDiff2(g,hStarL,hStarR,hL,hR,uL,uR)
+  !Delta = phip(g,hStarR,hL,hR)**2.d0 - 4.d0*phi(g,hStarR,hL,hR,uL,uR)*phiDDiff2(g,hStarL,hStarR,hL,hR,uL,uR)
+  Delta = phip(g,hStarR,hL,hR)**2.d0 - 4.d0*phiR*phiDDiff2(g,hStarL,hStarR,hL,hR,uL,uR)
   if (Delta<0) then 
      print *, "hstarL_old: ", hStarL, " hstarR_old: ", hStarR
      print *, "hL: ", hL, " hR: ", hR
@@ -266,6 +247,6 @@ double precision function hStarRFromQuadPhiFromBelow(g,hStarL,hStarR,hL,hR,uL,uR
      print *, 'Delta: ', Delta
      call abort
   END if
-  hStarRFromQuadPhiFromBelow = hStarR - 2.d0*phi(g,hStarR,hL,hR,uL,uR)/(phip(g,hStarR,hL,hR)+sqrt(Delta))
+  hStarRFromQuadPhiFromBelow = hStarR - 2.d0*phiR/(phip(g,hStarR,hL,hR)+sqrt(Delta))
 
 END function hStarRFromQuadPhiFromBelow

--- a/SWEs/Iterative_method_comparison/test_time.py
+++ b/SWEs/Iterative_method_comparison/test_time.py
@@ -20,7 +20,7 @@ lenmatrix_strong=2*10**6
 lenmatrix_weak=lenmatrix_strong*4
 lenmatrix=lenmatrix_strong+lenmatrix_weak
 
-
+print("Generating dataset of Riemann problems...")
 #Riemann problems with strong waves
 #matrix_strong=[[10**random.uniform(-4,4),10**random.uniform(-4,4),10**random.uniform(-2,2),-random.uniform(-2,2)] for i in range(lenmatrix_strong)]
 matrix_strong=[[10**random.uniform(-4,4),10**random.uniform(-4,4),10**random.uniform(-2,2),-10**random.uniform(-2,2)] for i in range(lenmatrix_strong)]
@@ -28,27 +28,23 @@ matrix_strong=[[10**random.uniform(-4,4),10**random.uniform(-4,4),10**random.uni
 matrix_weak=[[random.uniform(0.1,1),random.uniform(0.1,1),0,0] for i in range(lenmatrix_weak)]
 
 matrix=matrix_strong+matrix_weak
+print("Dataset generated")
 
 
-
+modules=[quad_TR,newton_TS,ostrowski_newton_TS,ostrowski_TS,mod_newton_TS,quad_below_TR,linear_TR]
+names=["quad_TR","newton_TS","ostrowski_newton_TS","ostrowski_TS","mod_newton_TS","quad_below_TR","linear_TR"]
+n_runs=7
 grav=1.
 conv_criteria=1
 tol=1.0E-12
 print("Results tol 1.e-12")
-print("Time quad_TR: ",min([quad_TR.hstar(tol=tol,grav=grav,conv_criteria=conv_criteria,rp_data=matrix,n_data=lenmatrix) for i in range(7)]))
-print("Time quad_below_TR: ",min([quad_below_TR.hstar(tol=tol,grav=grav,conv_criteria=conv_criteria,rp_data=matrix,n_data=lenmatrix) for i in range(7)]))
-print("Time linear_TR: ",min([linear_TR.hstar(tol=tol,grav=grav,conv_criteria=conv_criteria,rp_data=matrix,n_data=lenmatrix) for i in range(7)]))
-print("Time ostrowski_TS: ",min([ostrowski_TS.hstar(tol=tol,grav=grav,conv_criteria=conv_criteria,rp_data=matrix,n_data=lenmatrix) for i in range(7)]))
-print("Time ostrowski_newton_TS: ",min([ostrowski_newton_TS.hstar(tol=tol,grav=grav,conv_criteria=conv_criteria,rp_data=matrix,n_data=lenmatrix) for i in range(7)]))
-print("Time newton_TS: ",min([newton_TS.hstar(tol=tol,grav=grav,conv_criteria=conv_criteria,rp_data=matrix,n_data=lenmatrix) for i in range(7)]))
-print("Time mod_newton_TS: ",min([mod_newton_TS.hstar(tol=tol,grav=grav,conv_criteria=conv_criteria,rp_data=matrix,n_data=lenmatrix) for i in range(7)]))
-
+for name, modules in zip(names,modules):
+    print("############\nRunning "+name+"...")
+    print("Time "+name+": ",min([modules.hstar(tol=tol,grav=grav,conv_criteria=conv_criteria,rp_data=matrix,n_data=lenmatrix) for i in range(n_runs)]))
+    print("############")
 tol=1.0E-6
 print("Results tol 1.e-6")
-print("Time quad_TR: ",min([quad_TR.hstar(tol=tol,grav=grav,conv_criteria=conv_criteria,rp_data=matrix,n_data=lenmatrix) for i in range(7)]))
-print("Time quad_below_TR: ",min([quad_below_TR.hstar(tol=tol,grav=grav,conv_criteria=conv_criteria,rp_data=matrix,n_data=lenmatrix) for i in range(7)]))
-print("Time linear_TR: ",min([linear_TR.hstar(tol=tol,grav=grav,conv_criteria=conv_criteria,rp_data=matrix,n_data=lenmatrix) for i in range(7)]))
-print("Time ostrowski_TS: ",min([ostrowski_TS.hstar(tol=tol,grav=grav,conv_criteria=conv_criteria,rp_data=matrix,n_data=lenmatrix) for i in range(7)]))
-print("Time ostrowski_newton_TS: ",min([ostrowski_newton_TS.hstar(tol=tol,grav=grav,conv_criteria=conv_criteria,rp_data=matrix,n_data=lenmatrix) for i in range(7)]))
-print("Time newton_TS: ",min([newton_TS.hstar(tol=tol,grav=grav,conv_criteria=conv_criteria,rp_data=matrix,n_data=lenmatrix) for i in range(7)]))
-print("Time mod_newton_TS: ",min([mod_newton_TS.hstar(tol=tol,grav=grav,conv_criteria=conv_criteria,rp_data=matrix,n_data=lenmatrix) for i in range(7)]))
+for name, modules in zip(names,modules):
+    print("############\nRunning "+name+"...")
+    print("Time "+name+": ",min([modules.hstar(tol=tol,grav=grav,conv_criteria=conv_criteria,rp_data=matrix,n_data=lenmatrix) for i in range(n_runs)]))
+    print("############")

--- a/SWEs/Iterative_method_comparison/test_time.py
+++ b/SWEs/Iterative_method_comparison/test_time.py
@@ -36,15 +36,15 @@ names=["quad_TR","newton_TS","ostrowski_newton_TS","ostrowski_TS","mod_newton_TS
 n_runs=7
 grav=1.
 conv_criteria=1
-tol=1.0E-12
-print("Results tol 1.e-12")
-for name, modules in zip(names,modules):
-    print("############\nRunning "+name+"...")
-    print("Time "+name+": ",min([modules.hstar(tol=tol,grav=grav,conv_criteria=conv_criteria,rp_data=matrix,n_data=lenmatrix) for i in range(n_runs)]))
-    print("############")
 tol=1.0E-6
 print("Results tol 1.e-6")
-for name, modules in zip(names,modules):
+for name, module in zip(names,modules):
     print("############\nRunning "+name+"...")
-    print("Time "+name+": ",min([modules.hstar(tol=tol,grav=grav,conv_criteria=conv_criteria,rp_data=matrix,n_data=lenmatrix) for i in range(n_runs)]))
+    print("Time "+name+": ",min([module.hstar(tol=tol,grav=grav,conv_criteria=conv_criteria,rp_data=matrix,n_data=lenmatrix) for i in range(n_runs)]))
+    print("############")
+tol=1.0E-12
+print("Results tol 1.e-12")
+for name, module in zip(names,modules):
+    print("############\nRunning "+name+"...")
+    print("Time "+name+": ",min([module.hstar(tol=tol,grav=grav,conv_criteria=conv_criteria,rp_data=matrix,n_data=lenmatrix) for i in range(n_runs)]))
     print("############")

--- a/SWEs/Iterative_method_comparison/test_time.py
+++ b/SWEs/Iterative_method_comparison/test_time.py
@@ -1,18 +1,17 @@
 ####################
 #IMPORTING MODULES
 ####################
-
+print("Importing modules...")
 import numpy as np
 import random
-
-
-
 import modules.newton_TS as newton_TS
 import modules.mod_newton_TS as mod_newton_TS
 import modules.ostrowski_newton_TS as ostrowski_newton_TS
 import modules.ostrowski_TS as ostrowski_TS
 import modules.quad_TR as quad_TR
-
+import modules.quad_below_TR as quad_below_TR
+import modules.linear_TR as linear_TR
+print("Done importing modules.")
 
 random.seed(1)
 
@@ -37,6 +36,8 @@ conv_criteria=1
 tol=1.0E-12
 print("Results tol 1.e-12")
 print("Time quad_TR: ",min([quad_TR.hstar(tol=tol,grav=grav,conv_criteria=conv_criteria,rp_data=matrix,n_data=lenmatrix) for i in range(7)]))
+print("Time quad_below_TR: ",min([quad_below_TR.hstar(tol=tol,grav=grav,conv_criteria=conv_criteria,rp_data=matrix,n_data=lenmatrix) for i in range(7)]))
+print("Time linear_TR: ",min([linear_TR.hstar(tol=tol,grav=grav,conv_criteria=conv_criteria,rp_data=matrix,n_data=lenmatrix) for i in range(7)]))
 print("Time ostrowski_TS: ",min([ostrowski_TS.hstar(tol=tol,grav=grav,conv_criteria=conv_criteria,rp_data=matrix,n_data=lenmatrix) for i in range(7)]))
 print("Time ostrowski_newton_TS: ",min([ostrowski_newton_TS.hstar(tol=tol,grav=grav,conv_criteria=conv_criteria,rp_data=matrix,n_data=lenmatrix) for i in range(7)]))
 print("Time newton_TS: ",min([newton_TS.hstar(tol=tol,grav=grav,conv_criteria=conv_criteria,rp_data=matrix,n_data=lenmatrix) for i in range(7)]))
@@ -45,6 +46,8 @@ print("Time mod_newton_TS: ",min([mod_newton_TS.hstar(tol=tol,grav=grav,conv_cri
 tol=1.0E-6
 print("Results tol 1.e-6")
 print("Time quad_TR: ",min([quad_TR.hstar(tol=tol,grav=grav,conv_criteria=conv_criteria,rp_data=matrix,n_data=lenmatrix) for i in range(7)]))
+print("Time quad_below_TR: ",min([quad_below_TR.hstar(tol=tol,grav=grav,conv_criteria=conv_criteria,rp_data=matrix,n_data=lenmatrix) for i in range(7)]))
+print("Time linear_TR: ",min([linear_TR.hstar(tol=tol,grav=grav,conv_criteria=conv_criteria,rp_data=matrix,n_data=lenmatrix) for i in range(7)]))
 print("Time ostrowski_TS: ",min([ostrowski_TS.hstar(tol=tol,grav=grav,conv_criteria=conv_criteria,rp_data=matrix,n_data=lenmatrix) for i in range(7)]))
 print("Time ostrowski_newton_TS: ",min([ostrowski_newton_TS.hstar(tol=tol,grav=grav,conv_criteria=conv_criteria,rp_data=matrix,n_data=lenmatrix) for i in range(7)]))
 print("Time newton_TS: ",min([newton_TS.hstar(tol=tol,grav=grav,conv_criteria=conv_criteria,rp_data=matrix,n_data=lenmatrix) for i in range(7)]))


### PR DESCRIPTION
Some modifications to the source code after the required revision:

1. Two Riemann solvers have been added for each system (SWEs and EEs):
    - hstar_quad_below_TR (pstar_quad_below_TR): Approximates the root of the depth (pressure) function from above with the root of a quadratic Hermite polynomial. To construct the quadratic polynomial, lower and upper bounds for hstar (pstar) are required, h1 and h2 (p1 and p2). The quadratic polynomial approximates the depth (pressure) function from below between h1 and h2 (p1 and p2). p1 is fixed and p2 is updated in each iteration.
    - hstar_linear_TR (pstar_linear_TR): The same as above, but using a linear approximation of the depth (pressure) function.
2. A minor bug in pstar_quad_TR, where ustar was not being computed with pstar, was fixed.
3. The timing scripts have been updated.